### PR TITLE
Made parameter maps generic

### DIFF
--- a/spring-hateoas-ext/src/main/java/de/escalon/hypermedia/affordance/PartialUriTemplate.java
+++ b/spring-hateoas-ext/src/main/java/de/escalon/hypermedia/affordance/PartialUriTemplate.java
@@ -150,7 +150,7 @@ public class PartialUriTemplate {
      *         for expansion, must not be empty
      * @return expanded template
      */
-    public PartialUriTemplateComponents expand(Map<String, Object> parameters) {
+    public PartialUriTemplateComponents expand(Map<String, ?> parameters) {
         return getUriTemplateComponents(parameters, Collections.<String>emptyList());
     }
 
@@ -163,7 +163,7 @@ public class PartialUriTemplate {
      *         if not empty, retains given requiredArgs
      * @return uri components
      */
-    private PartialUriTemplateComponents getUriTemplateComponents(Map<String, Object> parameters, List<String>
+    private PartialUriTemplateComponents getUriTemplateComponents(Map<String, ?> parameters, List<String>
             requiredArgs) {
         Assert.notNull(parameters, "Parameters must not be null!");
 

--- a/spring-hateoas-ext/src/test/java/de/escalon/hypermedia/affordance/PartialUriTemplateTest.java
+++ b/spring-hateoas-ext/src/test/java/de/escalon/hypermedia/affordance/PartialUriTemplateTest.java
@@ -57,6 +57,20 @@ public class PartialUriTemplateTest {
     }
 
     @Test
+    public void testExpandAllComponentsWithStringStringMap() throws Exception {
+        final PartialUriTemplate template = new PartialUriTemplate("http://example.com/events{/city}{?eventName," +
+                "location}{#section}");
+        Map<String, String> val = new HashMap<String, String>();
+        val.put("city", "Wiesbaden");
+        val.put("eventName", "Revo Tour");
+        val.put("location", "Schlachthof");
+        val.put("section", "description");
+        final PartialUriTemplateComponents expanded = template.expand(val);
+        Assert.assertEquals("http://example.com/events/Wiesbaden?eventName=Revo+Tour&location=Schlachthof#description",
+                expanded.toString());
+    }
+
+    @Test
     public void testExpandQueryWithTwoVariables() throws Exception {
         final PartialUriTemplate template = new PartialUriTemplate("http://example.com/events/Wiesbaden{?eventName," +
                 "location}");


### PR DESCRIPTION
Current version of PartialUriTemplate infers that parameter map must be of type <String, Object>. If another type of map, like Map<String, String> is supplied, a different method expand(Object... parameters) quietly takes over, and the result gets totally wrong.

According to the source code (and general developer's practices) there's no reason why parameter map can not be generic like Map<String, ?> Updated method will work with other maps like Map<String, String> and Map<String, Integer> in the same way original Map<String, Object> have worked.

P.S. Struggling with Map<String, String> in my code took me a full day. Fixing PartialUriTemplate took just 5 minutes :)